### PR TITLE
Fix terminal colour side-effect

### DIFF
--- a/statistics.c
+++ b/statistics.c
@@ -344,6 +344,8 @@ int analyze_file(char *szFile) {
 
     printf("size =\t%.2f %s,  (%lld bytes)\n", readable_size, SIZE_UNITS[i], total_size);
 
+    if (color_flag)
+        printf("%s", RESET);
     return 0;
 
 }

--- a/statistics_circle.h
+++ b/statistics_circle.h
@@ -63,7 +63,7 @@
 #define KGRN  "\x1B[32m"
 #define KBLU  "\x1B[34m"
 #define KWHT  "\x1B[37m"
-#define RESET "\033[0m"
+#define RESET "\033[m"
 
 void create_circle(double complex *coordinates);
 


### PR DESCRIPTION
Colour was always forced to white.

Discovered while using Debian package of version 2.4.